### PR TITLE
refactor(component:pages): Supprime le composant Badge de la page About

### DIFF
--- a/src/app/home/visitors/about/about.page.component.html
+++ b/src/app/home/visitors/about/about.page.component.html
@@ -1,1 +1,0 @@
-<div class="flex justify-center pt-20"><app-badge /></div>

--- a/src/app/home/visitors/about/about.page.component.ts
+++ b/src/app/home/visitors/about/about.page.component.ts
@@ -1,9 +1,8 @@
 import { Component } from '@angular/core';
-import { BadgeDumbComponent } from '../../../shared/components/badge/badge.dumb.component';
 
 @Component({
   selector: 'app-about-page',
-  imports: [BadgeDumbComponent],
+  imports: [],
   templateUrl: './about.page.component.html',
   styleUrl: './about.page.component.css'
 })


### PR DESCRIPTION
- Retire l'importation et l'utilisation du composant `<app-badge>` dans la page About.
- Simplifie la structure du fichier HTML et le fichier TypeScript associé en supprimant une dépendance inutile.