### PR TITLE
chore(config:build): Supprime les références inutilisées

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,5 +1,3 @@
-/// <reference types="vitest" />
-
 import angular from '@analogjs/vite-plugin-angular';
 
 import { defineConfig } from 'vite';


### PR DESCRIPTION
- Retire les commentaires inutiles relatifs à Vitest.
- Cette modification simplifie la configuration et améliore la lisibilité.