### PR TITLE
feat(component:pages): Ajoute la page des Mentions Légales

### DIFF
--- a/src/app/legal/notice/notice.page.component.css
+++ b/src/app/legal/notice/notice.page.component.css
@@ -1,0 +1,1 @@
+/* Component-specific styles can be added here if needed */

--- a/src/app/legal/notice/notice.page.component.html
+++ b/src/app/legal/notice/notice.page.component.html
@@ -1,0 +1,53 @@
+<div class="max-w-7xl mx-auto px-4 py-16 mt-8">
+  <h1 class="text-2xl sm:text-2xl md:text-3xl lg:text-3xl xl:text-4xl font-bold bg-gradient-to-l from-accent to-text text-gradient inline-block mb-8">Mentions Légales</h1>
+
+  <div class="prose prose-lg max-w-none text-text border border-accent rounded-lg p-8 shadow-sm">
+    <p class="mb-4">
+      Dernière mise à jour : Vendredi 28 Mars 2025
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">1. Éditeur du Site</span></h2>
+    <p class="mb-4">
+      Ce site web est édité par NÉDELLEC Julien.
+    </p>
+    <p class="mb-4"><br>
+      Contact : contact&#64;nedellec-julien.fr
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">2. Hébergement</span></h2>
+    <p class="mb-4">
+      Ce site est hébergé par OVH, dont le siège social est situé à ROUBAIX.
+    </p>
+    <p class="mb-4">
+      Téléphone : 1007 (composez le +33 9 72 10 10 07 depuis une ligne en dehors de la France)
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">3. Propriété Intellectuelle</span></h2>
+    <p class="mb-4">
+      L'ensemble de ce site relève de la législation française et internationale sur le droit d'auteur et la propriété intellectuelle. Tous les droits de reproduction sont réservés, y compris pour les documents téléchargeables et les représentations iconographiques et photographiques.
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">4. Données Personnelles</span></h2>
+    <p class="mb-4">
+      Conformément à la loi "Informatique et Libertés" du 6 janvier 1978 modifiée, vous disposez d'un droit d'accès, de modification, de rectification et de suppression des données vous concernant. Pour exercer ce droit, veuillez nous contacter à contact&#64;nedellec-julien.fr.
+    </p>
+    <p class="mb-4">
+      Pour plus d'informations sur la façon dont nous traitons vos données, veuillez consulter notre <a href="/legal/privacy" class="text-accent hover:underline">Politique de Confidentialité</a>.
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">5. Cookies</span></h2>
+    <p class="mb-4">
+      Ce site utilise des cookies pour améliorer l'expérience utilisateur. En naviguant sur ce site, vous acceptez l'utilisation de cookies conformément à notre <a href="/legal/privacy" class="text-accent hover:underline">Politique de Confidentialité</a>.
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">6. Limitation de Responsabilité</span></h2>
+    <p class="mb-4">
+      Les informations contenues sur ce site sont aussi précises que possible et le site est périodiquement mis à jour, mais peut toutefois contenir des inexactitudes, des omissions ou des lacunes. Si vous constatez une erreur ou ce qui peut être un dysfonctionnement, merci de bien vouloir le signaler par email en décrivant le problème de la manière la plus précise possible.
+    </p>
+
+    <h2 class="text-2xl font-semibold text-text mt-8 mb-4"><span class="accent-underline">7. Liens Hypertextes</span></h2>
+    <p class="mb-4">
+      Ce site peut contenir des liens hypertextes vers d'autres sites. Julien.N n'a pas la possibilité de vérifier le contenu des sites ainsi visités, et n'assumera en conséquence aucune responsabilité de ce fait.
+    </p>
+  </div>
+</div>

--- a/src/app/legal/notice/notice.page.component.ts
+++ b/src/app/legal/notice/notice.page.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-notice',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './notice.page.component.html',
+  styleUrl: './notice.page.component.css'
+})
+export class NoticePageComponent {
+  // Add any component logic here
+}


### PR DESCRIPTION
- Implémente le composant `NoticePageComponent` avec sa structure HTML et ses styles de base.
- Inclut les sections officielles : Éditeur, Hébergement, Propriété Intellectuelle, et plus.