### PR TITLE
feat(script): Ajoute un script de conversion SVG en AVIF

### DIFF
--- a/frontend/convert-scripts/convert.sh
+++ b/frontend/convert-scripts/convert.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Convertir tous les SVG en AVIF
+
+SRC_DIR="frontend/public/icons/icons_stacks"
+DEST_DIR="frontend/public/icons/icons-stackss"
+
+mkdir -p "$DEST_DIR"
+
+for file in "$SRC_DIR"/*.svg; do
+  filename=$(basename "$file" .svg)
+  echo "Conversion de $file → $DEST_DIR/$filename.avif"
+
+  # Utilisation de sharp pour convertir l'image
+  node -e "
+    const sharp = require('sharp');
+    sharp('$file')
+      .resize(512)  // Redimensionner pour optimiser la taille
+      .toFormat('avif')  // Convertir au format AVIF
+      .toFile('$DEST_DIR/$filename.avif', (err, info) => {
+        if (err) {
+          console.error('Erreur de conversion:', err);
+        } else {
+          console.log('Conversion réussie:', info);
+        }
+      });
+  "
+done


### PR DESCRIPTION
- Implémente un script Bash pour convertir des fichiers SVG en AVIF avec redimensionnement.
- Utilise la bibliothèque Sharp pour la conversion et optimise la taille à 512px.